### PR TITLE
Update to work with TensorRT 10.7.0 and added support for getProfileShape

### DIFF
--- a/tensorrt-rs-sys/Cargo.toml
+++ b/tensorrt-rs-sys/Cargo.toml
@@ -17,3 +17,8 @@ cxx = { version = "1", features = ["c++17", "c++14"] }
 
 [build-dependencies]
 cxx-build = "1"
+
+[features]
+onnx = []
+lean = []
+builder = []

--- a/tensorrt-rs-sys/Cargo.toml
+++ b/tensorrt-rs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorrt-rs-sys"
-version = "0.1.2"
+version = "10.7.0"
 authors = ["Ming Yang <ymviv@qq.com>"]
 description = "Rust binding to NVIDIA TensorRT"
 repository = "https://github.com/vivym/tensorrt-rs"

--- a/tensorrt-rs-sys/build.rs
+++ b/tensorrt-rs-sys/build.rs
@@ -64,11 +64,18 @@ fn main() {
 
     println!("cargo:rustc-link-search={}", tensorrt_library_dir.to_string_lossy());
 
-    let libraries = vec![
+    let mut libraries = vec![
         "nvinfer",
-        "nvinfer_plugin",
-        "nvparsers",
+        "nvinfer_dispatch"
     ];
+
+    #[cfg(feature = "onnx")]
+    libs.push("nvonnxparser".to_string());
+    #[cfg(feature = "lean")]
+    libs.push("nvinfer_lean".to_string());
+    #[cfg(feature = "builder")]
+    libs.push("nvinfer_builder_resource".to_string());
+
 
     for library in libraries {
         println!("cargo:rustc-link-lib={}", library);

--- a/tensorrt-rs-sys/cxx/include/runtime.h
+++ b/tensorrt-rs-sys/cxx/include/runtime.h
@@ -12,6 +12,7 @@ using nvinfer1::IRuntime;
 using nvinfer1::ICudaEngine;
 using nvinfer1::IExecutionContext;
 using nvinfer1::Dims;
+using nvinfer1::OptProfileSelector;
 using logger::Logger;
 
 class CudaEngine;
@@ -48,6 +49,8 @@ public:
     CudaEngine(std::unique_ptr<ICudaEngine> engine) : engine_(std::move(engine)) {}
 
     rust::Vec<int32_t> get_tensor_shape(rust::Str name) const noexcept;
+
+    rust::Vec<int32_t> get_profile_shape(rust::Str tensor_name, int32_t profile_index, int32_t selector) const noexcept;
 
     int32_t get_tensor_dtype(rust::Str name) const noexcept {
         const auto name_str = std::string(name);

--- a/tensorrt-rs-sys/cxx/src/runtime.cpp
+++ b/tensorrt-rs-sys/cxx/src/runtime.cpp
@@ -25,7 +25,7 @@ rust::Vec<int32_t> CudaEngine::get_tensor_shape(rust::Str name) const noexcept {
 
 rust::Vec<int32_t> CudaEngine::get_profile_shape(rust::Str tensor_name, int32_t profile_index, int32_t selector) const noexcept {
     const auto name_str = std::string(tensor_name);
-    const auto dims engine_->getProfileShape(name_str.c_str(), profile_index, static_cast<OptProfileSelector>(selector));
+    const auto dims = engine_->getProfileShape(name_str.c_str(), profile_index, static_cast<OptProfileSelector>(selector));
     auto dims_vec = rust::Vec<int32_t>();
     dims_vec.reserve(dims.nbDims);
     for (int i = 0; i < dims.nbDims; i++) {

--- a/tensorrt-rs-sys/cxx/src/runtime.cpp
+++ b/tensorrt-rs-sys/cxx/src/runtime.cpp
@@ -23,6 +23,17 @@ rust::Vec<int32_t> CudaEngine::get_tensor_shape(rust::Str name) const noexcept {
     return dims_vec;
 }
 
+rust::Vec<int32_t> CudaEngine::get_profile_shape(rust::Str tensor_name, int32_t profile_index, int32_t selector) const noexcept {
+    const auto name_str = std::string(tensor_name);
+    const auto dims engine_->getProfileShape(name_str.c_str(), profile_index, static_cast<OptProfileSelector>(selector));
+    auto dims_vec = rust::Vec<int32_t>();
+    dims_vec.reserve(dims.nbDims);
+    for (int i = 0; i < dims.nbDims; i++) {
+        dims_vec.push_back(dims.d[i]);
+    }
+    return dims_vec;
+}
+
 std::unique_ptr<ExecutionContext>
 CudaEngine::create_execution_context() noexcept {
     auto context = engine_->createExecutionContext();

--- a/tensorrt-rs-sys/src/lib.rs
+++ b/tensorrt-rs-sys/src/lib.rs
@@ -39,6 +39,8 @@ pub(crate) mod ffi {
         // CudaEngine
         fn get_tensor_shape(self: &CudaEngine, name: &str) -> Vec<i32>;
 
+        fn get_profile_shape(self: &CudaEngine, tensor_name: &str, profile_index: i32, selector: i32) -> Vec<i32>;
+
         fn get_tensor_dtype(self: &CudaEngine, name: &str) -> i32;
 
         fn get_num_layers(self: &CudaEngine) -> i32;

--- a/tensorrt-rs-sys/src/runtime.rs
+++ b/tensorrt-rs-sys/src/runtime.rs
@@ -565,44 +565,41 @@ impl ExecutionContext {
 mod tests {
     use super::*;
     use crate::logger::Severity;
-    use std::env;
-
-    fn print_debug_info() {
-        println!("LD_LIBRARY_PATH: {:?}", env::var("LD_LIBRARY_PATH"));
-        println!("TENSORRT_LIB_PATH: {:?}", env::var("TENSORRT_LIB_PATH"));
-    }
-
     #[test]
     fn test_runtime() {
-        print_debug_info();
-        // use std::{io::Read, path::Path};
+        use std::{io::Read, path::Path};
 
         let mut runtime = Runtime::new().unwrap();
         runtime.logger().log(Severity::Info, "Hello, world!");
 
-        // let engine_path = Path::new("../tmp/pp-ocr-v4-det-fp16.engine");
-        // if engine_path.exists() {
-        //     let mut file = std::fs::File::open(engine_path).unwrap();
-        //     let mut data = Vec::new();
-        //     file.read_to_end(&mut data).unwrap();
+        let engine_path = Path::new("/opt/models/all-MiniLM-L12-v2.trt");
+        if engine_path.exists() {
+            let mut file = std::fs::File::open(engine_path).unwrap();
+            let mut data = Vec::new();
+            file.read_to_end(&mut data).unwrap();
 
-        //     let mut engine = runtime.deserialize(data.as_slice()).unwrap();
-        //     let _context = engine.create_execution_context().unwrap();
+            let mut engine = runtime.deserialize(data.as_slice()).unwrap();
+            let _context = engine.create_execution_context().unwrap();
 
-        //     let num_io_tensors = engine.get_num_io_tensors();
+            let num_io_tensors = engine.get_num_io_tensors();
 
-        //     let msg = format!("num_io_tensors: {}", num_io_tensors);
-        //     runtime.logger().log(Severity::Info, msg.as_str());
+            let mut msg = format!("num_io_tensors: {}", num_io_tensors);
+            runtime.logger().log(Severity::Info, msg.as_str());
 
-        //     for i in 0..num_io_tensors {
-        //         let name = engine.get_io_tensor_name(i);
-        //         let mode = engine.get_tensor_io_mode(name);
-        //         let shape = engine.get_tensor_shape(name);
-        //         let msg = format!("name: {}, mode: {:?}, shape: {:?}", name, mode, shape);
-        //         runtime.logger().log(Severity::Info, msg.as_str());
-        //     }
-        // } else {
-        //     runtime.logger().log(Severity::Info, "Engine file not found! Skip test!");
-        // }
+            for i in 0..num_io_tensors {
+                let name = engine.get_io_tensor_name(i);
+                let mode = engine.get_tensor_io_mode(name);
+                let shape = engine.get_tensor_shape(name);
+                if mode.is_input() {
+                    let max_shape = engine.get_profile_shape(name, 0, OptProfileSelector::Max);
+                    msg = format!("name: {}, mode: {:?}, shape: {:?}, max_shape: {:?}", name, mode, shape, max_shape);
+                } else {
+                    msg = format!("name: {}, mode: {:?}, shape: {:?}", name, mode, shape);
+                }                
+                runtime.logger().log(Severity::Info, msg.as_str());
+            }
+        } else {
+            runtime.logger().log(Severity::Info, "Engine file not found! Skip test!");
+        }
     }
 }

--- a/tensorrt-rs-sys/src/runtime.rs
+++ b/tensorrt-rs-sys/src/runtime.rs
@@ -302,7 +302,7 @@ impl CudaEngine {
     }
 
     pub fn get_profile_shape(&self, tensor_name: &str, profile_index: i32, selector: OptProfileSelector) -> Vec<i32> {
-        self.0.get_profile_shape(name, profile_index, selector as _)
+        self.0.get_profile_shape(tensor_name, profile_index, selector as _)
     }
 
     pub fn get_tensor_dtype(&self, name: &str) -> DataType {
@@ -565,37 +565,44 @@ impl ExecutionContext {
 mod tests {
     use super::*;
     use crate::logger::Severity;
+    use std::env;
+
+    fn print_debug_info() {
+        println!("LD_LIBRARY_PATH: {:?}", env::var("LD_LIBRARY_PATH"));
+        println!("TENSORRT_LIB_PATH: {:?}", env::var("TENSORRT_LIB_PATH"));
+    }
 
     #[test]
     fn test_runtime() {
-        use std::{io::Read, path::Path};
+        print_debug_info();
+        // use std::{io::Read, path::Path};
 
         let mut runtime = Runtime::new().unwrap();
         runtime.logger().log(Severity::Info, "Hello, world!");
 
-        let engine_path = Path::new("../tmp/pp-ocr-v4-det-fp16.engine");
-        if engine_path.exists() {
-            let mut file = std::fs::File::open(engine_path).unwrap();
-            let mut data = Vec::new();
-            file.read_to_end(&mut data).unwrap();
+        // let engine_path = Path::new("../tmp/pp-ocr-v4-det-fp16.engine");
+        // if engine_path.exists() {
+        //     let mut file = std::fs::File::open(engine_path).unwrap();
+        //     let mut data = Vec::new();
+        //     file.read_to_end(&mut data).unwrap();
 
-            let mut engine = runtime.deserialize(data.as_slice()).unwrap();
-            let _context = engine.create_execution_context().unwrap();
+        //     let mut engine = runtime.deserialize(data.as_slice()).unwrap();
+        //     let _context = engine.create_execution_context().unwrap();
 
-            let num_io_tensors = engine.get_num_io_tensors();
+        //     let num_io_tensors = engine.get_num_io_tensors();
 
-            let msg = format!("num_io_tensors: {}", num_io_tensors);
-            runtime.logger().log(Severity::Info, msg.as_str());
+        //     let msg = format!("num_io_tensors: {}", num_io_tensors);
+        //     runtime.logger().log(Severity::Info, msg.as_str());
 
-            for i in 0..num_io_tensors {
-                let name = engine.get_io_tensor_name(i);
-                let mode = engine.get_tensor_io_mode(name);
-                let shape = engine.get_tensor_shape(name);
-                let msg = format!("name: {}, mode: {:?}, shape: {:?}", name, mode, shape);
-                runtime.logger().log(Severity::Info, msg.as_str());
-            }
-        } else {
-            runtime.logger().log(Severity::Info, "Engine file not found! Skip test!");
-        }
+        //     for i in 0..num_io_tensors {
+        //         let name = engine.get_io_tensor_name(i);
+        //         let mode = engine.get_tensor_io_mode(name);
+        //         let shape = engine.get_tensor_shape(name);
+        //         let msg = format!("name: {}, mode: {:?}, shape: {:?}", name, mode, shape);
+        //         runtime.logger().log(Severity::Info, msg.as_str());
+        //     }
+        // } else {
+        //     runtime.logger().log(Severity::Info, "Engine file not found! Skip test!");
+        // }
     }
 }

--- a/tensorrt-rs-sys/src/runtime.rs
+++ b/tensorrt-rs-sys/src/runtime.rs
@@ -3,6 +3,13 @@ use cxx::UniquePtr;
 use cuda_rs::{event::CuEvent, stream::CuStream};
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+pub enum OptProfileSelector {
+    Min = 0,
+    Opt = 1,
+    Max = 2,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum DataType {
     // 32-bit floating point format.
     FLOAT = 0,
@@ -292,6 +299,10 @@ pub struct CudaEngine(pub(crate) UniquePtr<ffi::CudaEngine>);
 impl CudaEngine {
     pub fn get_tensor_shape(&self, name: &str) -> Vec<i32> {
         self.0.get_tensor_shape(name)
+    }
+
+    pub fn get_profile_shape(&self, tensor_name: &str, profile_index: i32, selector: OptProfileSelector) -> Vec<i32> {
+        self.0.get_profile_shape(name, profile_index, selector as _)
     }
 
     pub fn get_tensor_dtype(&self, name: &str) -> DataType {

--- a/tensorrt/Cargo.toml
+++ b/tensorrt/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 
 [dependencies]
 cuda-rs = "0.1"
-tensorrt-rs-sys = { verion = "10.7.0", git = "https://github.com/HarryCaveMan/tensorrt-rs.git" }
+tensorrt-rs-sys = "10.7.0"
 thiserror = "1"
 clap = { version = "4", features = ["derive"] ,optional = true }
 tch = { version = "0.14.0", optional = true}

--- a/tensorrt/Cargo.toml
+++ b/tensorrt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorrt"
-version = "0.1.0"
+version = "10.7.0"
 authors = ["Ming Yang <ymviv@qq.com>"]
 description = "Rust wrapper for NVIDIA TensorRT"
 repository = "https://github.com/vivym/tensorrt-rs"
@@ -13,9 +13,22 @@ edition = "2021"
 
 [dependencies]
 cuda-rs = "0.1"
-tensorrt-rs-sys = "0.1"
+tensorrt-rs-sys = { verion = "10.7.0", git = "https://github.com/HarryCaveMan/tensorrt-rs.git" }
 thiserror = "1"
+clap = { version = "4", features = ["derive"] ,optional = true }
+tch = { version = "0.14.0", optional = true}
 
-[dev-dependencies]
-clap = { version = "4", features = ["derive"] }
-tch = "0.14.0"
+
+# Install extra deps and compile examples only if the `examples` feature is enabled
+[features]
+examples = ["dep:clap","dep:tch"]
+
+[[example]]
+name = "pp_ocr"  # Name of your binary
+path = "examples/pp_ocr.rs"
+required-features = ["examples"]
+
+[[example]]
+name = "clip"  # Name of your binary
+path = "examples/clip.rs"
+required-features = ["examples"]


### PR DESCRIPTION
## Changes

Made all the changes necessary to upgrade the library to work with trt 10.7.0, also decided to make this library version match the latest version of trt it's been tested with.

Also, Made the examples compilation an optional feature, made a few trt features optional as well in case folks want to use a slimmed dist.


## Tests

Added tests, for the new function, output:

```txt
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/tensorrt_rs_sys-e2853508751cd536)

running 2 tests
[2025-01-25 03:53:07.799] [info] Hello, world!
[2025-01-25 03:53:07.799] [warning] Hello, world!
[2025-01-25 03:53:07.799] [error] Hello, world!
[2025-01-25 03:53:07.799] [critical] Hello, world!
test logger::tests::test_logger ... ok
[2025-01-25 03:53:07.991] [info] Hello, world!
[2025-01-25 03:53:08.033] [info] Loaded engine size: 128 MiB
[2025-01-25 03:53:08.200] [info] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +1872, now: CPU 0, GPU 1998 (MiB)
[2025-01-25 03:53:08.200] [info] num_io_tensors: 5
[2025-01-25 03:53:08.200] [info] name: input_ids, mode: INPUT, shape: [-1, -1], max_shape: [64, 512]
[2025-01-25 03:53:08.200] [info] name: attention_mask, mode: INPUT, shape: [-1, -1], max_shape: [64, 512]
[2025-01-25 03:53:08.200] [info] name: token_type_ids, mode: INPUT, shape: [-1, -1], max_shape: [64, 512]
[2025-01-25 03:53:08.200] [info] name: last_hidden_state, mode: OUTPUT, shape: [-1, -1, 384]
[2025-01-25 03:53:08.200] [info] name: sentence_embeddings, mode: OUTPUT, shape: [-1, 384]
test runtime::tests::test_runtime ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.43s

   Doc-tests tensorrt

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests tensorrt_rs_sys

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```